### PR TITLE
Build Daniel fundraising campaign site v1

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,22 +2,210 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>Regulation Standards Viewer</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="A mobile-first fundraising campaign hub to support Daniel Mattingly through direct giving, transparent updates, sharing tools, and a future merch storefront." />
+  <meta property="og:title" content="Give the Kid the Mic | Stand With Daniel" />
+  <meta property="og:description" content="A Louisville student spoke from the heart. Now the community can stand with him through direct support, sharing, and transparent campaign updates." />
+  <meta property="og:type" content="website" />
+  <title>Give the Kid the Mic | Stand With Daniel</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800;900&family=Permanent+Marker&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <header>
-    <h1>Regulation Standards Viewer</h1>
-    <nav>
-      <button onclick="scrollToSection('Service Related')">Service Related</button>
-      <button onclick="scrollToSection('Administration')">Administration</button>
-      <button onclick="scrollToSection('Facilities')">Facilities</button>
+  <a class="skip-link" href="#donate">Skip to donation options</a>
+
+  <header class="site-header" id="top">
+    <div class="brand-lockup" aria-label="Give the Kid the Mic campaign brand">
+      <div class="brand-icon" aria-hidden="true">🎙</div>
+      <div>
+        <p class="eyebrow">Louisville support campaign</p>
+        <strong>Give the Kid the Mic</strong>
+      </div>
+    </div>
+    <nav class="desktop-nav" aria-label="Primary navigation">
+      <a href="#story">Story</a>
+      <a href="#support">Support</a>
+      <a href="#shop">Shop</a>
+      <a href="#share">Share</a>
+      <a href="#contact">Contact</a>
     </nav>
-    <!-- Added minimum character hint to search placeholder -->
-    <input id="search" type="text" placeholder="Search (min. 2 chars)" oninput="performSearch()" />
-    <div id="search-results"></div>
+    <a class="nav-cta" href="#donate">Donate</a>
   </header>
-  <main id="content"></main>
+
+  <main>
+    <section class="hero section-pad">
+      <div class="hero-content">
+        <p class="pill">Family-approved campaign hub • placeholders marked clearly</p>
+        <h1>A Louisville student stood at the mic and told the truth.</h1>
+        <p class="hero-copy">Daniel Mattingly's story has reached people across the country because it is bigger than one speech. It is about courage, grief, dignity, and the basic human need to be seen.</p>
+        <div class="cta-row">
+          <a class="btn btn-primary" id="donate" href="https://www.gofundme.com/f/support-daniel-mattingly-after-loss" target="_blank" rel="noopener">Donate on GoFundMe</a>
+          <a class="btn btn-secondary" href="#share">Share his story</a>
+        </div>
+        <p class="microcopy">Direct donations route to the existing fundraiser. Merch is a placeholder until final fulfillment, pricing, and donation receipts are confirmed.</p>
+      </div>
+      <div class="hero-card" aria-label="Campaign visual placeholder">
+        <div class="portrait-placeholder">
+          <div class="portrait-hair"></div>
+          <div class="portrait-glasses"></div>
+          <div class="portrait-face"></div>
+          <div class="portrait-mic">🎙</div>
+        </div>
+        <div class="poster-text">
+          <span>Stand with</span>
+          <strong>Daniel</strong>
+          <em>Protect kids who tell the truth.</em>
+        </div>
+      </div>
+    </section>
+
+    <section class="stat-strip" aria-label="Campaign status placeholders">
+      <div>
+        <strong id="raisedTotal">$8,442</strong>
+        <span>reported raised at last research check</span>
+      </div>
+      <div>
+        <strong>$10,000</strong>
+        <span>reported fundraiser goal</span>
+      </div>
+      <div>
+        <strong>50%</strong>
+        <span>planned net merch profit donation</span>
+      </div>
+    </section>
+
+    <section class="section-pad split" id="story">
+      <div>
+        <p class="eyebrow">What happened</p>
+        <h2>One mic. One moment. A community response.</h2>
+      </div>
+      <div class="content-stack">
+        <p>Daniel Mattingly is an eighth-grade student from Louisville. He was selected to speak at graduation because of his student council involvement. His story gained attention after he went off script and spoke honestly about acceptance, grief, and the treatment he says students experienced.</p>
+        <p>He has also endured the loss of both parents. This site is built to direct support toward practical stability, basic needs, transportation, food, housing support, and family-approved updates.</p>
+        <div class="notice-card">
+          <strong>Campaign boundary</strong>
+          <p>This is not a harassment campaign. It is a support campaign. Do not contact, threaten, shame, or target students, staff, school personnel, or families.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="section-pad cards-section" id="support">
+      <div class="section-heading">
+        <p class="eyebrow">How support helps</p>
+        <h2>Direct support first. Transparent merch second.</h2>
+        <p>Every public-facing claim should be backed by the family, the fundraiser, or posted receipts.</p>
+      </div>
+      <div class="card-grid">
+        <article class="support-card">
+          <span>01</span>
+          <h3>Living stability</h3>
+          <p>Placeholder for family-approved language around food, housing, transportation, and immediate stability needs.</p>
+        </article>
+        <article class="support-card">
+          <span>02</span>
+          <h3>Grief support</h3>
+          <p>Placeholder for approved resources, counseling support, or practical care that protects Daniel's privacy.</p>
+        </article>
+        <article class="support-card">
+          <span>03</span>
+          <h3>Community advocacy</h3>
+          <p>Share the story without attacking individuals. Keep the focus on dignity, safety, and belonging for students.</p>
+        </article>
+        <article class="support-card">
+          <span>04</span>
+          <h3>Receipts and updates</h3>
+          <p>Placeholder for donation receipts, merch totals, transfer confirmations, and family-approved milestones.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="section-pad shop-section" id="shop">
+      <div class="section-heading">
+        <p class="eyebrow">Storefront placeholder</p>
+        <h2>Drop-shipping merch concept</h2>
+        <p>Shop buttons are intentionally placeholders. Add Printful, Printify, Shopify, Fourthwall, or another fulfillment link after the donation agreement and net-profit math are finalized.</p>
+      </div>
+      <div class="product-grid" id="productGrid"></div>
+      <div class="profit-card">
+        <h3>Transparent store language</h3>
+        <p>50% of net profit from every item will be donated to Daniel's family fundraiser. Net profit means sale price minus production, platform, payment processing, and shipping costs. Donation receipts and totals will be posted publicly.</p>
+        <p class="placeholder-note">Replace this with fixed-dollar giving per item when production costs are finalized, for example: “At least $8 from every shirt goes to the fundraiser.”</p>
+      </div>
+    </section>
+
+    <section class="section-pad proof-section" id="sources">
+      <div class="section-heading">
+        <p class="eyebrow">Verified links</p>
+        <h2>Story links and source placeholders</h2>
+      </div>
+      <div class="source-list">
+        <a href="https://people.com/students-graduation-speech-sparks-online-debate-11982782" target="_blank" rel="noopener">People coverage</a>
+        <a href="https://www.advocate.com/news/people/kentucky-middle-school-graduation-speech" target="_blank" rel="noopener">The Advocate coverage</a>
+        <a href="https://www.gofundme.com/f/support-daniel-mattingly-after-loss" target="_blank" rel="noopener">GoFundMe fundraiser</a>
+        <a href="#contact">Placeholder: WAVE / local coverage link</a>
+        <a href="#contact">Placeholder: LGBTQ Nation / additional source link</a>
+      </div>
+    </section>
+
+    <section class="section-pad share-section" id="share">
+      <div class="section-heading">
+        <p class="eyebrow">Share kit</p>
+        <h2>Copy, paste, and mobilize support.</h2>
+        <p>Use broad adult audiences. Do not target minors. Do not target sensitive identity categories directly.</p>
+      </div>
+      <div class="share-grid">
+        <article class="share-card">
+          <h3>Short caption</h3>
+          <p id="captionShort">A Louisville student spoke from the heart. Now the community can stand with him. Donate directly, share responsibly, and help fund stability for Daniel.</p>
+          <button class="copy-btn" data-copy="captionShort">Copy caption</button>
+        </article>
+        <article class="share-card">
+          <h3>Local caption</h3>
+          <p id="captionLocal">Louisville shows up for its kids. This campaign supports Daniel Mattingly through direct giving, transparent updates, and responsible community advocacy.</p>
+          <button class="copy-btn" data-copy="captionLocal">Copy caption</button>
+        </article>
+        <article class="share-card">
+          <h3>Hashtags</h3>
+          <p id="hashtags">#StandWithDaniel #GiveTheKidTheMic #LouisvilleShowsUp #LetThemSpeak #SpeakFromTheHeart</p>
+          <button class="copy-btn" data-copy="hashtags">Copy hashtags</button>
+        </article>
+      </div>
+    </section>
+
+    <section class="section-pad transparency" id="transparency">
+      <div>
+        <p class="eyebrow">Transparency rules</p>
+        <h2>Keep the campaign clean.</h2>
+      </div>
+      <ul class="check-list">
+        <li>Direct donation CTA goes to the verified fundraiser.</li>
+        <li>Merch remains a placeholder until fulfillment and donation math are confirmed.</li>
+        <li>No unsupported accusations, school logos, staff names, or harassment language.</li>
+        <li>Post donation receipts and transfer totals publicly.</li>
+        <li>Use family-approved photos, updates, and copy only.</li>
+      </ul>
+    </section>
+
+    <section class="section-pad contact-section" id="contact">
+      <div class="contact-card">
+        <p class="eyebrow">Contact</p>
+        <h2>Media, partnerships, and approvals</h2>
+        <p>Replace the placeholder contact details below with the family-approved campaign contact, media contact, or store operator inbox.</p>
+        <div class="contact-actions">
+          <a class="btn btn-primary" href="mailto:campaign-contact@example.com?subject=Stand%20With%20Daniel%20Campaign">Email campaign contact</a>
+          <a class="btn btn-secondary" href="#top">Back to top</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <p>Give the Kid the Mic • Stand With Daniel</p>
+    <p>Built as a mobile-first campaign placeholder. Replace all placeholders before public launch.</p>
+  </footer>
+
   <script src="viewer.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,27 +1,492 @@
-body { font-family: sans-serif; margin: 0; padding: 0; }
-header { padding: 1rem; background: #004080; color: white; }
-h1 { margin: 0 0 1rem 0; }
-nav button { margin-right: 1rem; }
-input[type=text] { width: 100%; padding: 0.5rem; margin-top: 1rem; }
-#search-results .result { background: #f0f0f0; margin-top: 0.5rem; padding: 0.5rem; }
-main { padding: 2rem; }
-.entry { margin-bottom: 2rem; border-bottom: 1px solid #ccc; padding-bottom: 1rem; }
-mark { background: yellow; font-weight: bold; }
+:root {
+  --ink: #101010;
+  --charcoal: #171717;
+  --paper: #f7f1e8;
+  --paper-soft: #fffaf2;
+  --muted: #6f665c;
+  --copper: #c46f3d;
+  --rust: #df4f2f;
+  --teal: #19b8c6;
+  --sage: #9fbf82;
+  --gold: #ead18e;
+  --line: rgba(16, 16, 16, 0.12);
+  --shadow: 0 24px 60px rgba(16, 16, 16, 0.18);
+  --radius: 26px;
+}
 
-/* Search results styling */
-#search-results {
-  margin-top: 0.5rem;
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  margin: 0;
+  font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--paper);
+  color: var(--ink);
+  line-height: 1.5;
 }
-#search-results p {
-  margin: 0.3rem 0;
-  font-size: 0.85rem;
+
+a { color: inherit; }
+img { max-width: 100%; display: block; }
+
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: 1rem;
+  background: var(--ink);
+  color: white;
+  padding: 0.75rem 1rem;
+  z-index: 1000;
 }
-#search-results em {
-  color: #666;
+.skip-link:focus { left: 1rem; }
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 1rem;
+  background: rgba(247, 241, 232, 0.92);
+  backdrop-filter: blur(18px);
+  border-bottom: 1px solid var(--line);
 }
-#search-results .result {
-  background: #f8f8f8;
-  margin-top: 0.5rem;
-  padding: 0.5rem;
-  border-radius: 4px;
+
+.brand-lockup {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 0;
+}
+.brand-icon {
+  width: 2.65rem;
+  height: 2.65rem;
+  display: grid;
+  place-items: center;
+  border-radius: 1rem;
+  background: var(--ink);
+  color: var(--paper);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.14);
+}
+.brand-lockup strong {
+  display: block;
+  font-size: 0.96rem;
+  line-height: 1.05;
+  white-space: nowrap;
+}
+.eyebrow {
+  margin: 0 0 0.4rem;
+  color: var(--copper);
+  font-size: 0.74rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.desktop-nav {
+  display: none;
+  gap: 1rem;
+  color: var(--muted);
+  font-weight: 700;
+  font-size: 0.9rem;
+}
+.desktop-nav a { text-decoration: none; }
+.desktop-nav a:hover { color: var(--ink); }
+.nav-cta {
+  text-decoration: none;
+  border-radius: 999px;
+  padding: 0.72rem 1rem;
+  background: var(--ink);
+  color: var(--paper);
+  font-weight: 900;
+  font-size: 0.9rem;
+}
+
+.section-pad { padding: 4rem 1rem; }
+.hero {
+  display: grid;
+  gap: 2rem;
+  min-height: calc(100vh - 72px);
+  align-items: center;
+  background:
+    radial-gradient(circle at 20% 15%, rgba(25, 184, 198, 0.2), transparent 28rem),
+    radial-gradient(circle at 90% 8%, rgba(223, 79, 47, 0.15), transparent 23rem),
+    linear-gradient(180deg, var(--paper-soft), var(--paper));
+  overflow: hidden;
+}
+.pill {
+  display: inline-flex;
+  width: fit-content;
+  margin: 0 0 1rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.55);
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+.hero h1,
+.section-heading h2,
+.split h2,
+.transparency h2,
+.contact-card h2 {
+  margin: 0;
+  font-size: clamp(2.45rem, 11vw, 6.25rem);
+  line-height: 0.9;
+  letter-spacing: -0.07em;
+  font-weight: 900;
+}
+.hero-copy {
+  max-width: 44rem;
+  color: var(--charcoal);
+  font-size: clamp(1.05rem, 4.5vw, 1.35rem);
+  font-weight: 650;
+}
+.cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.4rem;
+}
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 3.25rem;
+  padding: 0.9rem 1.15rem;
+  border-radius: 999px;
+  border: 2px solid var(--ink);
+  font-weight: 900;
+  text-decoration: none;
+  cursor: pointer;
+}
+.btn-primary {
+  background: var(--ink);
+  color: var(--paper);
+}
+.btn-secondary {
+  background: transparent;
+  color: var(--ink);
+}
+.microcopy,
+.placeholder-note {
+  color: var(--muted);
+  font-size: 0.88rem;
+  max-width: 40rem;
+}
+
+.hero-card {
+  position: relative;
+  min-height: 27rem;
+  border-radius: 2rem;
+  background: var(--ink);
+  color: var(--paper);
+  padding: 1rem;
+  overflow: hidden;
+  box-shadow: var(--shadow);
+  isolation: isolate;
+}
+.hero-card::before {
+  content: "";
+  position: absolute;
+  inset: -15%;
+  background:
+    radial-gradient(circle at 20% 25%, rgba(25, 184, 198, 0.9), transparent 13rem),
+    radial-gradient(circle at 85% 20%, rgba(196, 111, 61, 0.7), transparent 11rem),
+    repeating-linear-gradient(135deg, transparent 0 18px, rgba(255,255,255,0.06) 18px 20px);
+  z-index: -1;
+}
+.portrait-placeholder {
+  position: absolute;
+  inset: 1rem 1rem 6rem 1rem;
+  border: 3px solid rgba(255,255,255,0.65);
+  border-radius: 50% 48% 46% 54%;
+  background: radial-gradient(circle at 50% 35%, rgba(255,255,255,0.22), transparent 35%), rgba(255,255,255,0.06);
+}
+.portrait-face {
+  position: absolute;
+  left: 28%;
+  top: 27%;
+  width: 38%;
+  height: 42%;
+  border-radius: 45% 45% 48% 46%;
+  background: #f0c8ad;
+  box-shadow: inset 0 -18px 0 rgba(0,0,0,0.08);
+}
+.portrait-hair {
+  position: absolute;
+  left: 17%;
+  top: 10%;
+  width: 55%;
+  height: 44%;
+  border-radius: 60% 50% 50% 35%;
+  background: linear-gradient(135deg, #8e3e1e, #d87538 45%, #3b1c11);
+  transform: rotate(-8deg);
+  z-index: 2;
+}
+.portrait-glasses {
+  position: absolute;
+  left: 31%;
+  top: 37%;
+  width: 31%;
+  height: 11%;
+  border: 6px solid #111;
+  border-radius: 12px;
+  z-index: 3;
+  box-shadow: 56px 0 0 -6px transparent, 56px 0 0 0 #111;
+  opacity: 0.82;
+}
+.portrait-mic {
+  position: absolute;
+  right: 12%;
+  bottom: 12%;
+  font-size: 5rem;
+  transform: rotate(-15deg);
+}
+.poster-text {
+  position: absolute;
+  left: 1.15rem;
+  right: 1.15rem;
+  bottom: 1.15rem;
+  display: grid;
+  gap: 0.1rem;
+}
+.poster-text span {
+  font-family: "Permanent Marker", cursive;
+  font-size: 1.25rem;
+  color: var(--gold);
+}
+.poster-text strong {
+  font-size: clamp(3.5rem, 18vw, 7rem);
+  line-height: 0.8;
+  letter-spacing: -0.06em;
+  text-transform: uppercase;
+  color: var(--rust);
+}
+.poster-text em {
+  font-size: 1.05rem;
+  font-weight: 900;
+  font-style: normal;
+}
+
+.stat-strip {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1px;
+  background: var(--ink);
+  color: var(--paper);
+}
+.stat-strip div {
+  padding: 1.35rem 1rem;
+  background: var(--ink);
+}
+.stat-strip strong {
+  display: block;
+  font-size: 2rem;
+  font-weight: 900;
+  letter-spacing: -0.05em;
+}
+.stat-strip span { color: rgba(255,255,255,0.72); }
+
+.split {
+  display: grid;
+  gap: 2rem;
+  border-bottom: 1px solid var(--line);
+}
+.content-stack {
+  display: grid;
+  gap: 1rem;
+  color: var(--charcoal);
+  font-size: 1.05rem;
+}
+.notice-card,
+.profit-card,
+.contact-card {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 1.25rem;
+  background: rgba(255,255,255,0.58);
+  box-shadow: 0 14px 28px rgba(16,16,16,0.06);
+}
+.notice-card strong { font-size: 1.1rem; }
+
+.cards-section,
+.shop-section,
+.share-section,
+.proof-section {
+  border-bottom: 1px solid var(--line);
+}
+.section-heading {
+  display: grid;
+  gap: 0.75rem;
+  max-width: 48rem;
+  margin-bottom: 2rem;
+}
+.section-heading p:last-child { color: var(--muted); font-size: 1.05rem; }
+.card-grid,
+.product-grid,
+.share-grid {
+  display: grid;
+  gap: 1rem;
+}
+.support-card,
+.product-card,
+.share-card {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 1.25rem;
+  background: var(--paper-soft);
+}
+.support-card span {
+  display: inline-grid;
+  place-items: center;
+  width: 2.2rem;
+  height: 2.2rem;
+  border-radius: 50%;
+  background: var(--ink);
+  color: var(--paper);
+  font-weight: 900;
+}
+.support-card h3,
+.product-card h3,
+.share-card h3,
+.profit-card h3 { margin-bottom: 0.35rem; }
+.support-card p,
+.product-card p,
+.share-card p,
+.profit-card p { color: var(--muted); }
+.product-card {
+  display: grid;
+  gap: 0.85rem;
+  position: relative;
+  overflow: hidden;
+}
+.product-art {
+  min-height: 11rem;
+  border-radius: 1.25rem;
+  display: grid;
+  place-items: center;
+  background: var(--ink);
+  color: var(--paper);
+  text-align: center;
+  padding: 1rem;
+  font-weight: 900;
+  font-size: 1.65rem;
+  letter-spacing: -0.05em;
+  text-transform: uppercase;
+}
+.product-art.marker {
+  font-family: "Permanent Marker", cursive;
+  letter-spacing: 0;
+  font-weight: 400;
+}
+.product-meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  color: var(--muted);
+  font-weight: 800;
+  font-size: 0.9rem;
+}
+.product-card button,
+.copy-btn {
+  width: 100%;
+  min-height: 2.8rem;
+  border: 0;
+  border-radius: 999px;
+  background: var(--charcoal);
+  color: var(--paper);
+  font-weight: 900;
+  cursor: pointer;
+}
+.profit-card { margin-top: 1rem; }
+.source-list {
+  display: grid;
+  gap: 0.75rem;
+}
+.source-list a {
+  padding: 1rem;
+  border: 1px solid var(--line);
+  border-radius: 1rem;
+  background: rgba(255,255,255,0.55);
+  font-weight: 800;
+  text-decoration: none;
+}
+.source-list a:hover { background: var(--paper-soft); }
+.share-card p {
+  min-height: 5.5rem;
+  padding: 1rem;
+  border-radius: 1rem;
+  background: rgba(16,16,16,0.05);
+  color: var(--charcoal);
+}
+.transparency {
+  display: grid;
+  gap: 2rem;
+  background: var(--ink);
+  color: var(--paper);
+}
+.transparency .eyebrow { color: var(--gold); }
+.check-list {
+  display: grid;
+  gap: 0.85rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.check-list li {
+  padding: 1rem;
+  border-radius: 1rem;
+  background: rgba(255,255,255,0.08);
+  color: rgba(255,255,255,0.82);
+}
+.check-list li::before {
+  content: "✓";
+  margin-right: 0.65rem;
+  color: var(--sage);
+  font-weight: 900;
+}
+.contact-section { background: linear-gradient(180deg, var(--paper), var(--paper-soft)); }
+.contact-card {
+  max-width: 56rem;
+  margin: 0 auto;
+  text-align: center;
+}
+.contact-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+.site-footer {
+  display: grid;
+  gap: 0.25rem;
+  padding: 2rem 1rem;
+  background: var(--charcoal);
+  color: rgba(255,255,255,0.74);
+  font-size: 0.9rem;
+}
+.site-footer p { margin: 0; }
+.site-footer p:first-child { color: var(--paper); font-weight: 900; }
+
+@media (min-width: 720px) {
+  .site-header { padding: 1rem 2rem; }
+  .desktop-nav { display: flex; }
+  .section-pad { padding: 5.5rem 2rem; }
+  .hero { grid-template-columns: minmax(0, 1.05fr) minmax(22rem, 0.75fr); }
+  .stat-strip { grid-template-columns: repeat(3, 1fr); }
+  .split,
+  .transparency { grid-template-columns: 0.8fr 1.2fr; }
+  .card-grid,
+  .product-grid { grid-template-columns: repeat(2, 1fr); }
+  .share-grid { grid-template-columns: repeat(3, 1fr); }
+  .source-list { grid-template-columns: repeat(2, 1fr); }
+}
+
+@media (min-width: 1080px) {
+  .section-pad { padding-left: 5vw; padding-right: 5vw; }
+  .card-grid { grid-template-columns: repeat(4, 1fr); }
+  .product-grid { grid-template-columns: repeat(3, 1fr); }
+  .hero-card { min-height: 34rem; }
 }

--- a/viewer.js
+++ b/viewer.js
@@ -1,45 +1,75 @@
 const products = [
   {
-    name: "Give the Kid the Mic Tee",
+    name: "Not All Heroes Wear Capes Tee",
     price: "$28 placeholder",
     giveback: "Donation math pending",
-    art: "Give the Kid\nthe Mic",
-    style: "marker"
+    art: "Not All Heroes\nWear Capes",
+    description: "Hero portrait tee concept with rainbow advocacy lettering.",
+    style: "rainbow marker"
   },
   {
-    name: "Speak From the Heart Hoodie",
-    price: "$54 placeholder",
+    name: "Daniel 4 President Tee",
+    price: "$28 placeholder",
     giveback: "Donation math pending",
-    art: "Speak From\nthe Heart",
-    style: ""
+    art: "Daniel\n4 President",
+    description: "Campaign-style tee concept with bold rainbow varsity type.",
+    style: "rainbow"
   },
   {
-    name: "Stand With Daniel Sticker Pack",
-    price: "$12 placeholder",
+    name: "Official Merch Collage Tee",
+    price: "$32 placeholder",
     giveback: "Donation math pending",
-    art: "Let Them Speak",
-    style: "marker"
+    art: "Official\nMerch\nCollage",
+    description: "Multi-design front graphic concept using the approved merch set.",
+    style: "poster"
   },
   {
-    name: "A Mic. A Moment. A Movement. Tote",
+    name: "Speak From the Heart Brand Set",
     price: "$24 placeholder",
     giveback: "Donation math pending",
-    art: "A Mic.\nA Moment.\nA Movement.",
-    style: ""
+    art: "Speak From\nthe Heart",
+    description: "Clean campaign identity artwork for premium prints, stickers, and store branding.",
+    style: "soft"
   },
   {
-    name: "Protect Kids Yard Sign",
+    name: "A Mic. A Moment. A Movement. Poster",
     price: "$22 placeholder",
     giveback: "Donation math pending",
-    art: "Protect Kids\nWho Tell\nthe Truth",
+    art: "A Mic.\nA Moment.\nA Movement.",
+    description: "High-impact poster or hoodie-back design built around the movement frame.",
+    style: "grit"
+  },
+  {
+    name: "Let Them Speak Poster",
+    price: "$22 placeholder",
+    giveback: "Donation math pending",
+    art: "Let Them\nSpeak",
+    description: "Street-poster advocacy design with punk energy and direct support messaging.",
     style: "marker"
   },
   {
-    name: "Digital Support Card",
-    price: "$5 donation placeholder",
-    giveback: "Direct-giving option pending",
-    art: "You Matter.\nYour Voice\nMatters.",
-    style: ""
+    name: "Stand With Daniel Poster",
+    price: "$22 placeholder",
+    giveback: "Donation math pending",
+    art: "Stand With\nDaniel",
+    description: "Core campaign poster with the support line: protect kids who tell the truth.",
+    style: "poster"
+  },
+  {
+    name: "Give the Kid the Mic Emblem",
+    price: "$18 placeholder",
+    giveback: "Donation math pending",
+    art: "Give the Kid\nthe Mic",
+    description: "Primary badge/logo graphic for shirts, stickers, pins, and social avatars.",
+    style: "badge"
+  },
+  {
+    name: "Sticker Pack Mockup",
+    price: "$12 placeholder",
+    giveback: "Donation math pending",
+    art: "Sticker\nPack",
+    description: "Low-cost entry product with multiple campaign slogans and icon graphics.",
+    style: "soft marker"
   }
 ];
 
@@ -47,11 +77,12 @@ const productGrid = document.getElementById("productGrid");
 
 if (productGrid) {
   productGrid.innerHTML = products.map((product) => `
-    <article class="product-card">
+    <article class="product-card merch-card">
       <div class="product-art ${product.style}">${product.art.replaceAll("\n", "<br>")}</div>
       <div>
         <h3>${product.name}</h3>
-        <p>Placeholder product. Connect to a drop-shipping SKU after approval, fulfillment, and receipts are ready.</p>
+        <p>${product.description}</p>
+        <p class="placeholder-note">Mockup supplied. Connect final artwork file, drop-shipping SKU, and fulfillment link before launch.</p>
       </div>
       <div class="product-meta">
         <span>${product.price}</span>

--- a/viewer.js
+++ b/viewer.js
@@ -1,96 +1,84 @@
-// Global state object to hold all regulatory data
-let data = {};
+const products = [
+  {
+    name: "Give the Kid the Mic Tee",
+    price: "$28 placeholder",
+    giveback: "Donation math pending",
+    art: "Give the Kid\nthe Mic",
+    style: "marker"
+  },
+  {
+    name: "Speak From the Heart Hoodie",
+    price: "$54 placeholder",
+    giveback: "Donation math pending",
+    art: "Speak From\nthe Heart",
+    style: ""
+  },
+  {
+    name: "Stand With Daniel Sticker Pack",
+    price: "$12 placeholder",
+    giveback: "Donation math pending",
+    art: "Let Them Speak",
+    style: "marker"
+  },
+  {
+    name: "A Mic. A Moment. A Movement. Tote",
+    price: "$24 placeholder",
+    giveback: "Donation math pending",
+    art: "A Mic.\nA Moment.\nA Movement.",
+    style: ""
+  },
+  {
+    name: "Protect Kids Yard Sign",
+    price: "$22 placeholder",
+    giveback: "Donation math pending",
+    art: "Protect Kids\nWho Tell\nthe Truth",
+    style: "marker"
+  },
+  {
+    name: "Digital Support Card",
+    price: "$5 donation placeholder",
+    giveback: "Direct-giving option pending",
+    art: "You Matter.\nYour Voice\nMatters.",
+    style: ""
+  }
+];
 
-// DOM element references
-const contentEl = document.getElementById("content");
-const searchEl  = document.getElementById("search");
-const resultsEl = document.getElementById("search-results");
+const productGrid = document.getElementById("productGrid");
 
-fetch("data.json").then(r => r.json()).then(json => {
-  data = json;
-  renderAll();
-});
-
-function scrollToSection(section) {
-  const sectionEl = document.querySelector(`[data-section='${section}']`);
-  if (sectionEl) sectionEl.scrollIntoView({ behavior: "smooth" });
-}
-
-function renderAll() {
-  for (const section in data) {
-    const div = document.createElement("div");
-    div.setAttribute("data-section", section);
-    div.innerHTML = `<h2>${section}</h2>` + data[section].map(entry => `
-      <div class="entry" id="${section}-${entry.element}-${entry.loc}">
-        <h3>${entry.element} (${entry.loc})</h3>
-        ${["BHSO", "AODE", "Medicaid", "COA_HCSL", "COA_MHSU", "COA_RTX"].map(label => `
-          <div><strong>${label}:</strong><p>${entry[label] || "<em>No content</em>"}</p></div>
-        `).join("")}
+if (productGrid) {
+  productGrid.innerHTML = products.map((product) => `
+    <article class="product-card">
+      <div class="product-art ${product.style}">${product.art.replaceAll("\n", "<br>")}</div>
+      <div>
+        <h3>${product.name}</h3>
+        <p>Placeholder product. Connect to a drop-shipping SKU after approval, fulfillment, and receipts are ready.</p>
       </div>
-    `).join("");
-    contentEl.appendChild(div);
-  }
+      <div class="product-meta">
+        <span>${product.price}</span>
+        <span>${product.giveback}</span>
+      </div>
+      <button type="button" onclick="alert('Shop placeholder: connect this button to Shopify, Fourthwall, Printful, Printify, or another storefront when ready.')">Shop placeholder</button>
+    </article>
+  `).join("");
 }
 
-function performSearch() {
-  const query = searchEl.value.trim().toLowerCase();
-  resultsEl.innerHTML = "";
-  
-  // require at least 2 characters to prevent overwhelming results
-  if (query.length < 2) {
-    resultsEl.innerHTML = "<em>Type at least 2 characters to search.</em>";
-    return;
-  }
+const copyButtons = document.querySelectorAll(".copy-btn");
 
-  const hits = [];
-  // iterate all sections and entries to collect matches
-  for (const section of Object.keys(data)) {
-    for (const entry of data[section]) {
-      for (const field of ["BHSO", "AODE", "Medicaid", "COA_HCSL", "COA_MHSU", "COA_RTX"]) {
-        const content = entry[field] || "";
-        const lowerContent = content.toLowerCase();
-        const idx = lowerContent.indexOf(query);
-        if (idx !== -1) {
-          // Build a contextual snippet around the match
-          const start = Math.max(0, idx - 30);
-          const end   = Math.min(content.length, idx + query.length + 70);
-          let snippet = content.slice(start, end);
-          // Highlight occurrences of the query in the snippet (case-insensitive)
-          const regex = new RegExp(query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi');
-          snippet = snippet.replace(regex, match => `<mark>${match}</mark>`);
-          hits.push({ section, element: entry.element, loc: entry.loc, field, snippet });
-        }
-      }
-    }
-  }
+copyButtons.forEach((button) => {
+  button.addEventListener("click", async () => {
+    const targetId = button.getAttribute("data-copy");
+    const target = document.getElementById(targetId);
+    if (!target) return;
 
-  // Sort results by section name then element for consistency
-  hits.sort((a, b) => {
-    if (a.section === b.section) {
-      return a.element.localeCompare(b.element);
+    try {
+      await navigator.clipboard.writeText(target.innerText.trim());
+      const original = button.innerText;
+      button.innerText = "Copied";
+      setTimeout(() => {
+        button.innerText = original;
+      }, 1600);
+    } catch (error) {
+      button.innerText = "Select text to copy";
     }
-    return a.section.localeCompare(b.section);
   });
-
-  // Limit the number of displayed results to avoid overwhelming the user
-  const MAX_RESULTS = 10;
-  const displayed = hits.slice(0, MAX_RESULTS);
-
-  if (hits.length === 0) {
-    resultsEl.innerHTML = `<p>No matches found for <strong>${query}</strong>.</p>`;
-    return;
-  }
-
-  // If there are more results than displayed, inform the user
-  if (hits.length > MAX_RESULTS) {
-    const message = `<p>Showing ${MAX_RESULTS} of ${hits.length} matches. Refine your search for more specific results.</p>`;
-    resultsEl.innerHTML += message;
-  }
-
-  // Render each search hit
-  for (const hit of displayed) {
-    const id = `${hit.section}-${hit.element}-${hit.loc}`;
-    const link = `<a href="#${id}" onclick="document.getElementById('${id}').scrollIntoView({behavior: 'smooth'})">${hit.element} (${hit.loc}) — ${hit.field}</a>`;
-    resultsEl.innerHTML += `<div class="result">${link}<br><small>${hit.snippet}</small></div>`;
-  }
-}
+});


### PR DESCRIPTION
## What this adds
- Mobile-first Daniel Mattingly fundraising campaign landing page
- Direct GoFundMe CTA and share-first support flow
- Placeholder drop-shipping storefront section
- Transparent merch donation language
- Share kit with copy buttons
- Source link section and contact placeholders
- Guardrails against harassment, unsupported claims, and premature merch claims

## Files changed
- `index.html`
- `style.css`
- `viewer.js`

## Placeholder items to replace before public launch
- Final campaign contact email
- Final GoFundMe/current donation stats
- Final family-approved images/video
- Storefront provider links and SKUs
- Fixed-dollar donation amount per product
- Public receipt/update links
- Any additional verified story/source links

## Ship path
Review the PR/preview first. Merge to `main` only after the family-approved content, storefront math, and contact links are confirmed.